### PR TITLE
increase version of error for better dedupe

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   ],
   "dependencies": {
     "bufrw": "^0.9.4",
-    "error": "^5.1.1",
+    "error": "7.0.2",
     "long": "^2.4.0",
     "pegjs": "^0.8.0"
   },


### PR DESCRIPTION
Upgrading to latest will mean that error has less
dependencies and it will dedupe properly in tchannel-node

r: @kriskowal
