### PR TITLE
Implement IDLs interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -267,8 +267,9 @@ You can do the following
 ```js
 var path = require('path');
 var Thrift = require('thriftrw').Thrift;
-var service = Thrift.loadSync({
-  thriftFile: path.resolve(__dirname, 'services/user.thrift')
+var service = new Thrift({
+  entryPoint: path.resolve(__dirname, 'services/user.thrift'),
+  allowFilesystemAccess: true
 });
 
 var userUuid = service.modules.types.UUID({
@@ -295,12 +296,13 @@ Aliased include:
 include Types "../shared/types.thrift"
 ```
 
-To enable this you need to execute `Thrift.loadSync` with the `allowIncludeAlias` option set to true. e.g. 
+To enable this you need to create a `Thrift` with the `allowIncludeAlias` option set to true. e.g.
 
 ```js
-var thrift = Thrift.loadSync({
+var thrift = new Thrift({
   thriftFile: /* path to main thrift file */,
-  allowIncludeAlias: true
+  allowIncludeAlias: true,
+  allowFilesystemAccess: true
 });
 ```
 

--- a/ast.js
+++ b/ast.js
@@ -60,10 +60,12 @@ function Identifier(name, line, column) {
 Identifier.prototype.type = 'Identifier';
 
 module.exports.Include = Include;
-function Include(id, namespace) {
+function Include(id, namespace, line, column) {
     var self = this;
     self.id = id;
     self.namespace = namespace;
+    self.line = line;
+    self.column = column;
 }
 Include.prototype.type = 'Include';
 

--- a/lib/lcp.js
+++ b/lib/lcp.js
@@ -20,37 +20,29 @@
 
 'use strict';
 
-require('./binary');
-require('./boolean');
-require('./byte');
-require('./double');
-require('./i16');
-require('./i32');
-require('./i64');
-require('./map-entries');
-require('./thrift-idl');
-require('./map-object');
-require('./string');
-require('./tlist');
-require('./tmap');
-require('./tstruct');
-require('./void');
-require('./skip');
-require('./struct');
-require('./struct-skip');
-require('./recursion');
-require('./exception');
-require('./union');
-require('./service');
-require('./thrift');
-require('./list');
-require('./set');
-require('./map');
-require('./typedef');
-require('./const');
-require('./default');
-require('./enum');
-require('./unrecognized-exception');
-require('./include.js');
-require('./type-mismatch');
-require('./lcp');
+function lengthOfCommonPrefix(strings) {
+    if (strings.length === 0) {
+        return Infinity;
+    }
+    var longest = strings[0];
+    var length = longest.length;
+    for (var i = 1; i < strings.length; i++) {
+        var string = strings[i];
+        for (var j = 0; j < Math.min(length, string.length); j++) {
+            if (string[j] !== longest[j]) {
+                break;
+            }
+        }
+        length = j;
+    }
+    return length;
+}
+
+function longestCommonPath(paths) {
+    var length = lengthOfCommonPrefix(paths);
+    var end = paths[0].lastIndexOf('/', length - 1);
+    return paths[0].slice(0, end);
+}
+
+module.exports.lengthOfCommonPrefix = lengthOfCommonPrefix;
+module.exports.longestCommonPath = longestCommonPath;

--- a/test/idls.js
+++ b/test/idls.js
@@ -20,38 +20,29 @@
 
 'use strict';
 
-require('./binary');
-require('./boolean');
-require('./byte');
-require('./double');
-require('./i16');
-require('./i32');
-require('./i64');
-require('./map-entries');
-require('./thrift-idl');
-require('./map-object');
-require('./string');
-require('./tlist');
-require('./tmap');
-require('./tstruct');
-require('./void');
-require('./skip');
-require('./struct');
-require('./struct-skip');
-require('./recursion');
-require('./exception');
-require('./union');
-require('./service');
-require('./thrift');
-require('./list');
-require('./set');
-require('./map');
-require('./typedef');
-require('./const');
-require('./default');
-require('./enum');
-require('./unrecognized-exception');
-require('./include.js');
-require('./type-mismatch');
-require('./lcp');
-require('./idls');
+var test = require('tape');
+var fs = require('fs');
+var path = require('path');
+var Thrift = require('../thrift').Thrift;
+
+test('can round trip a thrift file through sources', function t(assert) {
+
+    var thrift = new Thrift({
+        entryPoint: path.join(__dirname, 'include-cyclic-a.thrift'),
+        fs: fs,
+        allowFsAccess: true,
+        allowIncludeAlias: true
+    });
+
+    var sources = thrift.getSources();
+    var rethrift = new Thrift({
+        entryPoint: sources.entryPoint,
+        idls: sources.idls,
+        allowIncludeAlias: true
+    });
+
+    assert.deepEquals(Object.keys(rethrift.models), Object.keys(thrift.models), 'all models survive round trip');
+
+    assert.end();
+});
+

--- a/test/include.js
+++ b/test/include.js
@@ -27,7 +27,7 @@ var path = require('path');
 
 test('loads a thrift file that imports synchronously', function t(assert) {
     var mainThrift = Thrift.loadSync({
-        thriftFile: path.join(__dirname, 'include-parent.thrift'),
+        entryPoint: path.join(__dirname, 'include-parent.thrift'),
         allowIncludeAlias: true
     });
     var importedThrift = mainThrift.modules.common;
@@ -70,7 +70,7 @@ test('loads a thrift file that imports synchronously', function t(assert) {
 
 test('include without explicitly defined namespace', function t(assert) {
     var thrift = Thrift.loadSync({
-        thriftFile: path.join(
+        entryPoint: path.join(
             __dirname,
             'include-filename-namespace.thrift'
         ),
@@ -84,7 +84,7 @@ test('include without explicitly defined namespace', function t(assert) {
 
 test('cyclic dependencies', function t(assert) {
     var thriftA = Thrift.loadSync({
-        thriftFile: path.join(
+        entryPoint: path.join(
             __dirname,
             'include-cyclic-a.thrift'
         ),
@@ -118,7 +118,7 @@ test('bad include paths', function t(assert) {
 
     function badIncludePaths() {
         Thrift.loadSync({
-            thriftFile: path.join(
+            entryPoint: path.join(
                 __dirname,
                 'include-error-not-path.thrift'
             ),
@@ -137,7 +137,7 @@ test('unknown thrift module name', function t(assert) {
 
     function unknownThriftModule() {
         Thrift.loadSync({
-            thriftFile: path.join(
+            entryPoint: path.join(
                 __dirname,
                 'include-error-unknown-module.thrift'
             ),
@@ -156,7 +156,7 @@ test('bad thrift module name', function t(assert) {
 
     function badThriftModuleName() {
         Thrift.loadSync({
-            thriftFile: path.join(
+            entryPoint: path.join(
                 __dirname,
                 'include-error-invalid-filename-as-namespace.thrift'
             ),
@@ -168,8 +168,8 @@ test('bad thrift module name', function t(assert) {
 test('includes from opts.source throws', function t(assert) {
     assert.throws(
         includesViaSource,
-        /Must set opts.thriftFile on instantiation to resolve include paths/,
-        'throws when instantiated via opts.source without opts.thriftFile set'
+        /Thrift must be constructed with/,
+        'throws when instantiated via opts.source without opts.entryPoint set'
     );
     assert.end();
 

--- a/test/include.js
+++ b/test/include.js
@@ -26,9 +26,10 @@ var Thrift = require('../thrift').Thrift;
 var path = require('path');
 
 test('loads a thrift file that imports synchronously', function t(assert) {
-    var mainThrift = Thrift.loadSync({
+    var mainThrift = new Thrift({
         entryPoint: path.join(__dirname, 'include-parent.thrift'),
-        allowIncludeAlias: true
+        allowIncludeAlias: true,
+        allowFilesystemAccess: true
     });
     var importedThrift = mainThrift.modules.common;
 
@@ -69,12 +70,13 @@ test('loads a thrift file that imports synchronously', function t(assert) {
 });
 
 test('include without explicitly defined namespace', function t(assert) {
-    var thrift = Thrift.loadSync({
+    var thrift = new Thrift({
         entryPoint: path.join(
             __dirname,
             'include-filename-namespace.thrift'
         ),
-        allowIncludeAlias: true
+        allowIncludeAlias: true,
+        allowFilesystemAccess: true
     });
 
     assert.ok(thrift.modules.typedef,
@@ -83,12 +85,13 @@ test('include without explicitly defined namespace', function t(assert) {
 });
 
 test('cyclic dependencies', function t(assert) {
-    var thriftA = Thrift.loadSync({
+    var thriftA = new Thrift({
         entryPoint: path.join(
             __dirname,
             'include-cyclic-a.thrift'
         ),
-        allowIncludeAlias: true
+        allowIncludeAlias: true,
+        allowFilesystemAccess: true
     });
 
     var thriftB = thriftA.B;
@@ -117,12 +120,13 @@ test('bad include paths', function t(assert) {
     assert.end();
 
     function badIncludePaths() {
-        Thrift.loadSync({
+        return new Thrift({
             entryPoint: path.join(
                 __dirname,
                 'include-error-not-path.thrift'
             ),
-            allowIncludeAlias: true
+            allowIncludeAlias: true,
+            allowFilesystemAccess: true
         });
     }
 });
@@ -136,12 +140,13 @@ test('unknown thrift module name', function t(assert) {
     assert.end();
 
     function unknownThriftModule() {
-        Thrift.loadSync({
+        return new Thrift({
             entryPoint: path.join(
                 __dirname,
                 'include-error-unknown-module.thrift'
             ),
-            allowIncludeAlias: true
+            allowIncludeAlias: true,
+            allowFilesystemAccess: true
         });
     }
 });
@@ -155,12 +160,13 @@ test('bad thrift module name', function t(assert) {
     assert.end();
 
     function badThriftModuleName() {
-        Thrift.loadSync({
+        return new Thrift({
             entryPoint: path.join(
                 __dirname,
                 'include-error-invalid-filename-as-namespace.thrift'
             ),
-            allowIncludeAlias: true
+            allowIncludeAlias: true,
+            allowFilesystemAccess: true
         });
     }
 });

--- a/test/lcp.js
+++ b/test/lcp.js
@@ -1,0 +1,81 @@
+// Copyright (c) 2015 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+'use strict';
+
+var test = require('tape');
+var lcp = require('../lib/lcp');
+
+var prefixTests = [
+    {strings: [], length: Infinity},
+    {strings: [''], length: 0},
+    {strings: ['a', 'b'], length: 0},
+    {strings: ['ac', 'ab'], length: 1},
+    {strings: ['aac', 'aab'], length: 2},
+    {strings: ['aac', 'aab', 'aab'], length: 2},
+    {strings: ['aaaa', 'aaa', 'aa', 'a'], length: 1}
+];
+
+test('lengths of common prefixes', function t(assert) {
+    for (var i = 0; i < prefixTests.length; i++) {
+        var prefixTest = prefixTests[i];
+        assert.equal(
+            lcp.lengthOfCommonPrefix(prefixTest.strings),
+            prefixTest.length,
+            'length of common prefix among ' +
+            JSON.stringify(prefixTest.strings)
+        );
+    }
+    assert.end();
+});
+
+var pathTests = [
+    {paths: [
+        '/home/luser/app/idl/alice/alice.thrift',
+        '/home/luser/app/idl/bob/bob.thrift',
+        '/home/luser/app/idl/charlie/charlie.thrift',
+        '/home/luser/app/idl/common.thrift'
+    ], path: '/home/luser/app/idl'},
+    {paths: [
+        '/home/luser/app/idl/alice/alice.thrift',
+        '/home/luser/app/idl/alice.thrift'
+    ], path: '/home/luser/app/idl'},
+    {paths: [
+        '/home/luser/app/idl/alice',
+        '/home/luser/app/idl/bob'
+    ], path: '/home/luser/app/idl'},
+    {paths: [
+        '/home/luser/app/idl/',
+        '/home/luser/app/idl/'
+    ], path: '/home/luser/app/idl'}
+];
+
+test('common parent directory', function t(assert) {
+    for (var i = 0; i < pathTests.length; i++) {
+        var pathTest = pathTests[i];
+        assert.equal(
+            lcp.longestCommonPath(pathTest.paths),
+            pathTest.path,
+            'length of common parent directory among ' +
+            JSON.stringify(pathTest.paths)
+        );
+    }
+    assert.end();
+});

--- a/thrift-idl.pegjs
+++ b/thrift-idl.pegjs
@@ -22,7 +22,7 @@ Header
 
 Include
   = IncludeToken namespace:Identifier? __ id:Literal {
-    return new ast.Include(id, namespace);
+    return new ast.Include(id, namespace, line(), column());
   }
 
 CppInclude

--- a/thrift.js
+++ b/thrift.js
@@ -131,11 +131,6 @@ function Thrift(options) {
 
 }
 
-Thrift.loadSync = function loadSync(options) {
-    options.allowFilesystemAccess = true;
-    return new Thrift(options);
-};
-
 Thrift.prototype.models = 'module';
 
 Thrift.prototype.getType = function getType(name) {

--- a/thrift.js
+++ b/thrift.js
@@ -55,19 +55,38 @@ function Thrift(options) {
 
     assert(options, 'options required');
     assert(typeof options === 'object', 'options must be object');
-    assert(options.source || options.thriftFile,
-        'opts.source or opts.thriftFile required');
+    assert(options.source || options.entryPoint, 'opts.entryPoint required');
 
-    self.thriftFile = options.thriftFile ?
-        path.resolve(options.thriftFile) : null;
-
+    // Coerce weakly-deprecated single include usage
     if (options.source) {
         assert(typeof options.source === 'string', 'source must be string');
-        self.source = options.source;
+        options.entryPoint = 'source.thrift';
+        options.idls = {'source.thrift': options.source};
     }
 
-    if (self.thriftFile && !self.source) {
-        self.source = fs.readFileSync(self.thriftFile, 'ascii');
+    // filename to source
+    self.idls = options.idls || Object.create(null);
+    // filename to Thrift instance
+    self.memo = options.memo || Object.create(null);
+
+    self.filename = options.entryPoint;
+    self.dirname = path.dirname(self.filename);
+    self.memo[self.filename] = self;
+
+    // Grant file system access for resolving includes, as opposed to lifting
+    // includes from provided options.idls alone.
+    self.fs = options.fs;
+    if (options.allowFilesystemAccess) {
+        self.fs = fs;
+    }
+
+    var source = self.idls[options.entryPoint];
+    if (!source) {
+        assert.ok(self.fs, self.filename + ': Thrift must be constructed with either a complete set of options.idls or options.fs access');
+        assert.ok(self.filename, 'Thrift must be constructed with a options.entryPoint');
+        self.filename = path.resolve(self.filename);
+        source = self.fs.readFileSync(self.filename, 'ascii');
+        self.idls[self.filename] = source;
     }
 
     self.strict = options.strict !== undefined ? options.strict : true;
@@ -99,26 +118,21 @@ function Thrift(options) {
     self.surface = self;
 
     self.linked = false;
-    self.filepathThriftMemo = options.filepathThriftMemo || Object.create(null);
     self.allowIncludeAlias = options.allowIncludeAlias || false;
 
-    if (self.thriftFile) {
-        self.dirname = path.dirname(self.thriftFile);
-        self.filepathThriftMemo[self.thriftFile] = self;
-    }
-
-    if (options.source) {
-        // Two passes permits forward references and cyclic references.
-        self.compile();
+    // Separate compile/link passes permits forward references and cyclic
+    // references.
+    self.compile(source);
+    // We only link from the root Thrift object.
+    if (!options.noLink) {
         self.link();
     }
+
 }
 
 Thrift.loadSync = function loadSync(options) {
-    var thrift = new Thrift(options);
-    thrift.compile();
-    thrift.link();
-    return thrift;
+    options.allowFilesystemAccess = true;
+    return new Thrift(options);
 };
 
 Thrift.prototype.models = 'module';
@@ -149,9 +163,9 @@ Thrift.prototype.baseTypes = {
     binary: ThriftBinary
 };
 
-Thrift.prototype.compile = function compile() {
+Thrift.prototype.compile = function compile(source) {
     var self = this;
-    var syntax = idl.parse(self.source);
+    var syntax = idl.parse(source);
     assert.equal(syntax.type, 'Program', 'expected a program');
     self._compile(syntax.headers);
     self._compile(syntax.definitions);
@@ -190,15 +204,10 @@ Thrift.prototype._compile = function _compile(defs) {
 Thrift.prototype.compileInclude = function compileInclude(def) {
     var self = this;
 
-    assert(
-        self.dirname,
-        'Must set opts.thriftFile on instantiation to resolve include paths'
-    );
-
     if (def.id.lastIndexOf('./', 0) === 0 ||
         def.id.lastIndexOf('../', 0) === 0) {
-        var thriftFile = path.resolve(self.dirname, def.id);
         var ns = def.namespace && def.namespace.name;
+        var filename = path.join(self.dirname, def.id);
 
         // If include isn't name, get filename sans *.thrift file extension.
         if (!self.allowIncludeAlias || !ns) {
@@ -213,16 +222,18 @@ Thrift.prototype.compileInclude = function compileInclude(def) {
 
         var model;
 
-        if (self.filepathThriftMemo[thriftFile]) {
-            model = self.filepathThriftMemo[thriftFile];
+        if (self.memo[filename]) {
+            model = self.memo[filename];
         } else {
             model = new Thrift({
-                thriftFile: thriftFile,
+                entryPoint: filename,
+                fs: self.fs,
+                idls: self.idls,
+                memo: self.memo,
                 strict: self.strict,
-                filepathThriftMemo: self.filepathThriftMemo,
-                allowIncludeAlias: true
+                allowIncludeAlias: true,
+                noLink: true
             });
-            model.compile();
         }
 
         self.define(ns, def, model);

--- a/thrift.js
+++ b/thrift.js
@@ -321,7 +321,10 @@ Thrift.prototype.resolve = function resolve(def) {
     } else if (def.type === 'Map') {
         return new ThriftMap(self.resolve(def.keyType), self.resolve(def.valueType), def.annotations);
     } else {
-        assert.fail(util.format('Can\'t get reader/writer for definition with unknown type %s at %s:%s', def.type, def.line, def.column));
+        assert.fail(util.format(
+            'Can\'t get reader/writer for definition with unknown type %s at %s:%s',
+            def.type, def.line, def.column
+        ));
     }
 };
 


### PR DESCRIPTION
These changes permit a Thrift instance to bootstrap from the file system (using entryPoint and allowFilesystemAccess options), get reduced to an {entryPoint, idls} object via thrift.getSources(), and then get fed back into the Thrift constructor, demonstrating how a service would bootstrap, how it would implement its Meta::thriftIDL endpoint, then how tcurl would bootstrap from the result.

r @raynos @malandrew 