### PR TITLE
Fix lcp for single files

### DIFF
--- a/lib/lcp.js
+++ b/lib/lcp.js
@@ -41,7 +41,7 @@ function lengthOfCommonPrefix(strings) {
 function longestCommonPath(paths) {
     var length = lengthOfCommonPrefix(paths);
     var end = paths[0].lastIndexOf('/', length - 1);
-    return paths[0].slice(0, end);
+    return paths[0].slice(0, end + 1);
 }
 
 module.exports.lengthOfCommonPrefix = lengthOfCommonPrefix;

--- a/test/lcp.js
+++ b/test/lcp.js
@@ -52,19 +52,25 @@ var pathTests = [
         '/home/luser/app/idl/bob/bob.thrift',
         '/home/luser/app/idl/charlie/charlie.thrift',
         '/home/luser/app/idl/common.thrift'
-    ], path: '/home/luser/app/idl'},
+    ], path: '/home/luser/app/idl/'},
     {paths: [
         '/home/luser/app/idl/alice/alice.thrift',
         '/home/luser/app/idl/alice.thrift'
-    ], path: '/home/luser/app/idl'},
+    ], path: '/home/luser/app/idl/'},
     {paths: [
         '/home/luser/app/idl/alice',
         '/home/luser/app/idl/bob'
-    ], path: '/home/luser/app/idl'},
+    ], path: '/home/luser/app/idl/'},
     {paths: [
         '/home/luser/app/idl/',
         '/home/luser/app/idl/'
-    ], path: '/home/luser/app/idl'}
+    ], path: '/home/luser/app/idl/'},
+    {paths: [
+        'service.thrift'
+    ], path: ''},
+    {paths: [
+        '/home/luser/app/idl/service.thrift'
+    ], path: '/home/luser/app/idl/'}
 ];
 
 test('common parent directory', function t(assert) {

--- a/test/thrift.js
+++ b/test/thrift.js
@@ -28,10 +28,30 @@ var Thrift = require('../thrift').Thrift;
 
 var thrift;
 
-test('thrift parses', function t(assert) {
+test('thrift parses from source', function t(assert) {
     var filename = path.join(__dirname, 'thrift.thrift');
     var source = fs.readFileSync(filename, 'ascii');
     thrift = new Thrift({source: source});
+    assert.equal(
+        thrift.getSources().entryPoint,
+        'service.thrift',
+        'Correct default entryPoint value when no includes'
+    );
+    assert.pass('thrift parses');
+    assert.end();
+});
+
+test('thrift parses from entryPoint', function t(assert) {
+    var filename = path.join(__dirname, 'thrift.thrift');
+    thrift = new Thrift({
+        entryPoint: filename,
+        allowFilesystemAccess: true
+    });
+    assert.equal(
+        thrift.getSources().entryPoint,
+        'thrift.thrift',
+        'Correct default entryPoint value when no includes'
+    );
     assert.pass('thrift parses');
     assert.end();
 });

--- a/thrift.js
+++ b/thrift.js
@@ -61,8 +61,8 @@ function Thrift(options) {
     // Coerce weakly-deprecated single include usage
     if (options.source) {
         assert(typeof options.source === 'string', 'source must be string');
-        options.entryPoint = 'source.thrift';
-        options.idls = {'source.thrift': options.source};
+        options.entryPoint = 'service.thrift';
+        options.idls = {'service.thrift': options.source};
     }
 
     // filename to source
@@ -154,9 +154,9 @@ Thrift.prototype.getSources = function getSources() {
     var idls = {};
     for (var index = 0; index < filenames.length; index++) {
         var filename = filenames[index];
-        idls[filename.slice(common.length + 1)] = self.idls[filename];
+        idls[filename.slice(common.length)] = self.idls[filename];
     }
-    var entryPoint = self.filename.slice(common.length + 1);
+    var entryPoint = self.filename.slice(common.length);
     return {entryPoint: entryPoint, idls: idls};
 };
 


### PR DESCRIPTION
The longest common path algorithm didn't address the case when there was a single file or when a path was not absolute to the file system. This PR fixes that. 