### PR TITLE
Less allocations

### DIFF
--- a/benchmarks/cases.js
+++ b/benchmarks/cases.js
@@ -22,6 +22,10 @@
 
 /* global Buffer */
 
+var WriteResult = require('bufrw/base').WriteResult;
+var ReadResult = require('bufrw/base').ReadResult;
+var LengthResult = require('bufrw/base').LengthResult;
+
 function JsonCase(args) {
     this.payload = args.payload;
     this.verify = args.verify;
@@ -42,11 +46,14 @@ function ThriftCase(args) {
     this.rw = args.rw;
 }
 
+var lenRes = new LengthResult();
+var writeRes = new WriteResult();
+var readRes = new ReadResult();
 ThriftCase.prototype.bench = function benchThriftCase() {
-    var lenRes = this.rw.byteLength(this.payload);
+    this.rw.poolByteLength(lenRes, this.payload);
     var buffer = new Buffer(lenRes.length);
-    this.rw.writeInto(this.payload, buffer, 0);
-    this.rw.readFrom(buffer, 0);
+    this.rw.poolWriteInto(writeRes, this.payload, buffer, 0);
+    this.rw.poolReadFrom(readRes, buffer, 0);
 };
 
 module.exports.JsonCase = JsonCase;

--- a/boolean.js
+++ b/boolean.js
@@ -27,14 +27,15 @@ var TYPE = require('./TYPE');
 var BooleanRW = bufrw.Base(
     booleanByteLength,
     readTBooleanFrom,
-    writeTBooleanInto);
+    writeTBooleanInto,
+    true);
 
-function booleanByteLength() {
-    return new bufrw.LengthResult(null, bufrw.UInt8.width);
+function booleanByteLength(destResult) {
+    return destResult.reset(null, bufrw.UInt8.width);
 }
 
-function readTBooleanFrom(buffer, offset) {
-    var res = bufrw.UInt8.readFrom(buffer, offset);
+function readTBooleanFrom(destResult, buffer, offset) {
+    var res = bufrw.UInt8.poolReadFrom(destResult, buffer, offset);
     // istanbul ignore else
     if (!res.err) {
         res.value = Boolean(res.value);
@@ -42,11 +43,11 @@ function readTBooleanFrom(buffer, offset) {
     return res;
 }
 
-function writeTBooleanInto(bool, buffer, offset) {
+function writeTBooleanInto(destResult, bool, buffer, offset) {
     if (typeof bool !== 'boolean') {
-        return new bufrw.WriteResult(errors.expected(bool, 'a boolean'), offset);
+        return destResult.reset(errors.expected(bool, 'a boolean'), offset);
     }
-    return bufrw.UInt8.writeInto(Number(bool), buffer, offset);
+    return bufrw.UInt8.poolWriteInto(destResult, Number(bool), buffer, offset);
 }
 
 function ThriftBoolean() { }

--- a/enum.js
+++ b/enum.js
@@ -142,7 +142,7 @@ EnumRW.prototype.poolReadFrom = function poolReadFrom(destResult, buffer, offset
         return destResult.reset(errors.InvalidEnumerationValueError({
             enumName: this.model.name,
             value: value
-        }), null, null);
+        }), offset, null);
     }
     return destResult.reset(null, offset, name);
 };

--- a/i64.js
+++ b/i64.js
@@ -30,97 +30,99 @@ var errors = require('bufrw/errors');
 
 // istanbul ignore next
 function I64RW() {
+    bufrw.Base.call(this);
 }
+
+util.inherits(I64RW, bufrw.Base);
 
 I64RW.prototype.lengthResult = bufrw.LengthResult.just(8);
 
-I64RW.prototype.byteLength = function byteLength(value) {
-    return this.lengthResult;
+I64RW.prototype.poolByteLength = function poolByteLength(destResult, value) {
+    return destResult.reset(null, 8);
 };
 
-I64RW.prototype.writeInto = function writeInto(value, buffer, offset) {
+I64RW.prototype.poolWriteInto = function writeInto(destResult, value, buffer, offset) {
     if (value instanceof Buffer) {
         value.copy(buffer, offset, 0, 8);
-        return new bufrw.WriteResult(null, offset + 8);
+        return destResult.reset(null, offset + 8);
     } else if (typeof value === 'number') {
         buffer.writeInt32BE(value / Math.pow(2, 32), offset, true);
         buffer.writeInt32BE(value, offset + 4, true);
-        return new bufrw.WriteResult(null, offset + 8);
+        return destResult.reset(null, offset + 8);
     } else if (Array.isArray(value)) {
-        return this.writeArrayInt64Into(value, buffer, offset);
+        return this.writeArrayInt64Into(destResult, value, buffer, offset);
     } else if (typeof value === 'string') {
-        return this.writeStringInt64Into(value, buffer, offset);
+        return this.writeStringInt64Into(destResult, value, buffer, offset);
     } else if (value && typeof value === 'object') {
-        return this.writeObjectInt64Into(value, buffer, offset);
+        return this.writeObjectInt64Into(destResult, value, buffer, offset);
     } else {
-        return bufrw.WriteResult.error(errors.expected(value,
-            'i64 representation'));
+        return destResult.reset(errors.expected(value, 'i64 representation'));
     }
 };
 
 I64RW.prototype.writeObjectInt64Into =
-function writeObjectInt64Into(value, buffer, offset) {
+function writeObjectInt64Into(destResult, value, buffer, offset) {
     if (typeof value.high !== 'number' && typeof value.hi !== 'number') {
-        return bufrw.WriteResult.error(errors.expected(value,
-            '{hi[gh], lo[w]} with high bits, or other i64 representation'));
+        return destResult.reset(errors.expected(value,
+            '{hi[gh], lo[w]} with high bits, or other i64 representation'), null);
     }
     if (typeof value.low !== 'number' && typeof value.lo !== 'number') {
-        return bufrw.WriteResult.error(errors.expected(value,
-            '{hi[gh], lo[w]} with low bits, or other i64 representation'));
+        return destResult.reset(errors.expected(value,
+            '{hi[gh], lo[w]} with low bits, or other i64 representation'), null);
     }
     // Does not validate range of hi or lo value
     buffer.writeInt32BE(value.high || value.hi, offset, true);
     buffer.writeInt32BE(value.low || value.lo, offset + 4, true);
-    return new bufrw.WriteResult(null, offset + 8);
+    return destResult.reset(null, offset + 8);
 };
 
 I64RW.prototype.writeArrayInt64Into =
-function writeArrayInt64Into(value, buffer, offset) {
+function writeArrayInt64Into(destResult, value, buffer, offset) {
     if (value.length !== 8) {
-        return new bufrw.WriteResult(errors.expected(value,
-            'an array of 8 bytes, or other i64 representation'));
+        return destResult.reset(errors.expected(value,
+            'an array of 8 bytes, or other i64 representation'), null);
     }
     // Does not validate individual byte values, particularly allowing unsigned
     // or signed byte values without discrimination.
     for (var index = 0; index < 8; index++) {
         buffer[offset + index] = value[index] & 0xFF;
     }
-    return new bufrw.WriteResult(null, offset + 8);
+    return destResult.reset(null, offset + 8);
 };
 
 I64RW.prototype.writeStringInt64Into =
-function writeStringInt64Into(value, buffer, offset) {
+function writeStringInt64Into(destResult, value, buffer, offset) {
     if (value.length !== 16) {
-        return new bufrw.WriteResult(errors.expected(value,
-            'a string of 16 hex characters, or other i64 representation'));
+        return destResult.reset(errors.expected(value,
+            'a string of 16 hex characters, or other i64 representation'), null);
     }
 
     var hi = parseInt(value.slice(0, 8), 16);
     if (hi !== hi) { // NaN
-        return new bufrw.WriteResult(errors.expected(value,
-            'a string of hex characters, or other i64 representation'));
+        return destResult.reset(errors.expected(value,
+            'a string of hex characters, or other i64 representation'), null);
     }
     var lo = parseInt(value.slice(8, 16), 16);
     if (lo !== lo) { // NaN
-        return new bufrw.WriteResult(errors.expected(value,
-            'a string of hex characters, or other i64 representation'));
+        return destResult.reset(errors.expected(value,
+            'a string of hex characters, or other i64 representation'), null);
     }
 
     buffer.writeInt32BE(hi, offset);
     buffer.writeInt32BE(lo, offset + 4);
-    return new bufrw.WriteResult(null, offset + 8);
+    return destResult.reset(null, offset + 8);
 };
 
 function I64LongRW() {}
 
 util.inherits(I64LongRW, I64RW);
 
-I64LongRW.prototype.readFrom = function readFrom(buffer, offset) {
+I64LongRW.prototype.poolReadFrom = function poolReadFrom(destResult, buffer, offset) {
     var value = Long.fromBits(
         buffer.readInt32BE(offset + 4, 4, true),
         buffer.readInt32BE(offset, 4, true)
     );
-    return new bufrw.ReadResult(null, offset + 8, value);
+    return destResult.reset(null, offset + 8, value);
 };
 
 var i64LongRW = new I64LongRW();
@@ -129,22 +131,22 @@ function I64DateRW() {}
 
 util.inherits(I64DateRW, I64RW);
 
-I64DateRW.prototype.readFrom = function readFrom(buffer, offset) {
+I64DateRW.prototype.poolReadFrom = function poolReadFrom(destResult, buffer, offset) {
     var long = Long.fromBits(
         buffer.readInt32BE(offset + 4, 4, true),
         buffer.readInt32BE(offset + 0, 4, true)
     );
     var ms = long.toNumber();
     var value = new Date(ms);
-    return new bufrw.ReadResult(null, offset + 8, value);
+    return destResult.reset(null, offset + 8, value);
 };
 
-I64DateRW.prototype.writeInto = function writeInto(value, buffer, offset) {
+I64DateRW.prototype.poolWriteInto = function poolWriteInto(destResult, value, buffer, offset) {
     if (typeof value === 'string') {
         value = Date.parse(value);
     }
     value = Long.fromNumber(+value);
-    return this.writeObjectInt64Into(value, buffer, offset);
+    return this.writeObjectInt64Into(destResult, value, buffer, offset);
 };
 
 var i64DateRW = new I64DateRW();
@@ -153,10 +155,10 @@ function I64BufferRW() {}
 
 util.inherits(I64BufferRW, I64RW);
 
-I64BufferRW.prototype.readFrom = function readTInt64From(buffer, offset) {
+I64BufferRW.prototype.poolReadFrom = function poolReadTInt64From(destResult, buffer, offset) {
     var value = new Buffer(8);
     buffer.copy(value, 0, offset, offset + 8);
-    return new bufrw.ReadResult(null, offset + 8, value);
+    return destResult.reset(null, offset + 8, value);
 };
 
 var i64BufferRW = new I64BufferRW();

--- a/i64.js
+++ b/i64.js
@@ -41,7 +41,7 @@ I64RW.prototype.poolByteLength = function poolByteLength(destResult, value) {
     return destResult.reset(null, 8);
 };
 
-I64RW.prototype.poolWriteInto = function writeInto(destResult, value, buffer, offset) {
+I64RW.prototype.poolWriteInto = function poolWriteInto(destResult, value, buffer, offset) {
     if (value instanceof Buffer) {
         value.copy(buffer, offset, 0, 8);
         return destResult.reset(null, offset + 8);

--- a/map-object.js
+++ b/map-object.js
@@ -36,6 +36,8 @@ function MapObjectRW(ktype, vtype) {
     if (this.vtype.rw.width) {
         this.byteLength = this.mapVarFixbyteLength;
     }
+
+    bufrw.Base.call(this);
 }
 inherits(MapObjectRW, bufrw.Base);
 

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     }
   ],
   "dependencies": {
-    "bufrw": "^0.9.4",
+    "bufrw": "^1.2.0",
     "error": "7.0.2",
     "long": "^2.4.0",
     "pegjs": "^0.8.0"

--- a/struct.js
+++ b/struct.js
@@ -33,15 +33,6 @@ var util = require('util');
 var ThriftUnrecognizedException = require('./unrecognized-exception')
     .ThriftUnrecognizedException;
 
-var LengthResult = bufrw.LengthResult;
-var WriteResult = bufrw.WriteResult;
-var ReadResult = bufrw.ReadResult;
-
-// Shared result instances
-var lengthResult = new LengthResult();
-var readResult = new ReadResult();
-var writeResult = new WriteResult();
-
 var readType = require('./read').readType;
 
 function ThriftField(def, struct) {
@@ -426,7 +417,7 @@ StructRW.prototype.poolReadFrom = function poolReadFrom(destResult, buffer, offs
             }), offset);
         }
 
-        result = field.valueType.rw.poolReadFrom(readResult, buffer, offset);
+        result = field.valueType.rw.poolReadFrom(destResult, buffer, offset);
         // istanbul ignore if
         if (result.err) {
             return destResult.reset(result.err, offset);

--- a/struct.js
+++ b/struct.js
@@ -429,7 +429,7 @@ StructRW.prototype.poolReadFrom = function poolReadFrom(destResult, buffer, offs
         result = field.valueType.rw.poolReadFrom(readResult, buffer, offset);
         // istanbul ignore if
         if (result.err) {
-            return result;
+            return destResult.reset(result.err, offset);
         }
         offset = result.offset;
         // TODO promote return error of set to a ReadResult error
@@ -439,7 +439,7 @@ StructRW.prototype.poolReadFrom = function poolReadFrom(destResult, buffer, offs
     // Validate required fields
     var err = this.model.validateStruct(struct);
     if (err) {
-        return destResult.reset(err);
+        return destResult.reset(err, offset);
     }
 
     return destResult.reset(null, offset, this.model.finalize(struct));

--- a/test/skip.js
+++ b/test/skip.js
@@ -24,6 +24,7 @@
 var test = require('tape');
 var formatError = require('bufrw/interface').formatError;
 var skip = require('../skip').skipField;
+var ReadResult = require('bufrw/base').ReadResult;
 
 test('skips a bool', createCase([
     0x02, // typeid:1 -- 2, BOOL
@@ -163,7 +164,8 @@ test('skip map of strings to i32s', createCase([
 
 function createCase(bytes) {
     return function t(assert) {
-        var result = skip(new Buffer(bytes), 0);
+        var res = new ReadResult();
+        var result = skip(res, new Buffer(bytes), 0);
         if (result.err) {
             assert.comment(formatError(result.err), {color: true});
             return assert.end(result.err);


### PR DESCRIPTION
This isn't quite zero alloc but it's definitely less allocations. I might try and get this branch faster before merging, but right now it passes all tests and does show a performance gain, though it wasn't the 2x improvement I was hoping for.

after, and with bufrw 1.2.0:
```
p25 1.28µs p50 1.35µs p75 1.53µs p90 1.71µs stddev 37.5ns q3-q1/2  372ns 0 thrift
p25 2.10µs p50 2.22µs p75 2.61µs p90 2.77µs stddev 61.0ns q3-q1/2  355ns 0 json
p25 2.56µs p50 2.74µs p75 3.22µs p90 3.35µs stddev 90.5ns q3-q1/2  422ns 1 thrift
p25 3.55µs p50 3.81µs p75 4.50µs p90 4.60µs stddev  131ns q3-q1/2  671ns 1 json
p25 14.2µs p50 14.9µs p75 16.5µs p90 17.8µs stddev  355ns q3-q1/2 1.60µs 10 thrift
p25 13.6µs p50 14.1µs p75 15.5µs p90 17.0µs stddev  280ns q3-q1/2 2.13µs 10 json
p25  132µs p50  138µs p75  144µs p90  154µs stddev 2.98µs q3-q1/2 9.74µs 100 thrift
p25  119µs p50  126µs p75  132µs p90  140µs stddev 3.18µs q3-q1/2 8.95µs 100 json
p25 1.37ms p50 1.39ms p75 1.42ms p90 1.43ms stddev 11.8µs q3-q1/2 37.2µs 1000 thrift
p25 1.26ms p50 1.29ms p75 1.31ms p90 1.35ms stddev 16.0µs q3-q1/2 40.5µs 1000 json
p25 13.4ms p50 13.5ms p75 13.6ms p90 13.7ms stddev 32.8µs q3-q1/2  151µs 10000 thrift
p25 17.6ms p50 17.6ms p75 17.6ms p90 17.7ms stddev 0.00ns q3-q1/2 91.4µs 10000 json
```

before, and with bufrw 1.1.0:
```
p25 1.34µs p50 1.38µs p75 1.45µs p90 1.70µs stddev 18.3ns q3-q1/2  309ns 0 thrift
p25 2.14µs p50 2.28µs p75 2.75µs p90 2.84µs stddev 72.0ns q3-q1/2  377ns 0 json
p25 3.08µs p50 3.28µs p75 3.90µs p90 4.01µs stddev  105ns q3-q1/2  482ns 1 thrift
p25 3.59µs p50 3.75µs p75 4.27µs p90 4.65µs stddev 80.5ns q3-q1/2  781ns 1 json
p25 17.4µs p50 18.5µs p75 20.1µs p90 21.7µs stddev  528ns q3-q1/2 1.97µs 10 thrift
p25 13.5µs p50 14.1µs p75 15.7µs p90 16.9µs stddev  347ns q3-q1/2 1.52µs 10 json
p25  162µs p50  166µs p75  173µs p90  180µs stddev 2.08µs q3-q1/2 8.50µs 100 thrift
p25  117µs p50  122µs p75  128µs p90  134µs stddev 2.72µs q3-q1/2 8.12µs 100 json
p25 1.66ms p50 1.70ms p75 1.72ms p90 1.77ms stddev 18.9µs q3-q1/2 54.3µs 1000 thrift
p25 1.23ms p50 1.27ms p75 1.29ms p90 1.32ms stddev 19.4µs q3-q1/2 52.9µs 1000 json
p25 17.2ms p50 17.2ms p75 17.2ms p90 17.3ms stddev 0.00ns q3-q1/2 81.9µs 10000 thrift
p25 16.7ms p50 16.7ms p75 16.7ms p90 16.8ms stddev 0.00ns q3-q1/2  121µs 10000 json
```

r @kriskowal @jcorbin @Raynos 